### PR TITLE
Rolling Back VECTORCAST_DIR changes

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -1,3 +1,7 @@
+4 Sept 2019 (0.56)
+* Finished rolling back changes introduced in 0.43 and 0.44. They will
+  eventually be back though
+
 4 Sept 2019 (0.55)
 * Add support for new VCAST_RPTS_SELF_CONTAINED option added in VC19 SP2
 * Add support for using Manage API to generate XML reports if available

--- a/src/main/java/com/vectorcast/plugins/vectorcastexecution/VectorCASTCommand.java
+++ b/src/main/java/com/vectorcast/plugins/vectorcastexecution/VectorCASTCommand.java
@@ -60,15 +60,7 @@ public class VectorCASTCommand extends Builder implements SimpleBuildStep {
      * @return windows command
      */
     public final String getWinCommand() {
-        //
-        // Older builds of VectorCAST do not assume VectorCAST executables are on the the system PATH.
-        // They used an environment variable called VECTORCAST_DIR, we will add that to our PATH.
-        //
-        //
-        return "setlocal\n"
-               + "set PATH=%PATH%;%VECTORCAST_DIR%\n"
-               + winCommand
-               + "\nendlocal";
+        return winCommand;
     }
 
     /**
@@ -76,13 +68,7 @@ public class VectorCASTCommand extends Builder implements SimpleBuildStep {
      * @return unix command
      */
     public final String getUnixCommand() {
-        //
-        // Older builds of VectorCAST do not assume VectorCAST executables are on the the system PATH.
-        // They used an environment variable called VECTORCAST_DIR, we will add that to our PATH.
-        //
-        //
-        return "PATH=\"${PATH:+\"$PATH:\"}$VECTORCAST_DIR\"\n"
-               + unixCommand;
+        return unixCommand;
     }
     
     /**

--- a/src/main/resources/scripts/copy_build_dir.py
+++ b/src/main/resources/scripts/copy_build_dir.py
@@ -121,11 +121,8 @@ if __name__ == '__main__':
     else:
         nocase = ""
 
-    exe_env = os.environ.copy()
-    if 'VECTORCAST_DIR' in os.environ:
-        exe_env['PATH'] = os.pathsep.join([os.environ.get('PATH', ''), exe_env['VECTORCAST_DIR']])
-
-    p = subprocess.Popen("manage --project " + ManageProjectName + " --build-directory-name --level " + Level + " -e " + Env,shell=True,stdout=subprocess.PIPE, env=exe_env)
+    manageCMD = os.path.join(os.environ.get('VECTORCAST_DIR'), "manage")
+    p = subprocess.Popen(manageCMD + "--project " + ManageProjectName + " --build-directory-name --level " + Level + " -e " + Env,shell=True,stdout=subprocess.PIPE)
     out, err = p.communicate()
     list = out.split(os.linesep)
     build_dir = ''

--- a/src/main/resources/scripts/generate-results.py
+++ b/src/main/resources/scripts/generate-results.py
@@ -49,13 +49,6 @@ global wait_loops
 
 verbose = False
 
-# Versions of VectorCAST prior to 2019 relied on the environment variable VECTORCAST_DIR.
-# We will use that variable as a fall back if the VectorCAST executables aren't on the system path.
-has_exe = lambda p, x : os.access(os.path.join(p, x), os.X_OK)
-has_vcast_exe = lambda p : has_exe(p, 'manage') or has_exe(p, 'manage.exe')
-vcast_dirs = (path for path in os.environ["PATH"].split(os.pathsep) if has_vcast_exe(path))
-vectorcast_install_dir = next(vcast_dirs, os.environ.get("VECTORCAST_DIR", ""))
-
 #
 # Internal - jUnit works best with one overall file for all test results
 #
@@ -123,7 +116,7 @@ def checkUseNewReportsAndAPI():
             print "Reports forced to be old/legacy, so use them"
         return False
     # Look for existence of file that only exists in distribution with the new reports
-    check_file = os.path.join(vectorcast_install_dir,
+    check_file = os.path.join(os.environ.get('VECTORCAST_DIR'),
                              "python",
                              "vector",
                              "apps",
@@ -159,7 +152,8 @@ def readManageVersion(ManageFile):
 def getManageEnvs(FullManageProjectName):
     manageEnvs = {}
 
-    callStr = "manage --project " + FullManageProjectName + " --build-directory-name"
+    cmd_prefix = os.environ.get('VECTORCAST_DIR') + os.sep
+    callStr = cmd_prefix + "manage --project " + FullManageProjectName + " --build-directory-name"
     out_mgt = runManageWithWait(callStr, silent=True)
     if verbose:
         print out_mgt
@@ -429,14 +423,16 @@ def buildReports(FullManageProjectName = None, level = None, envName = None, gen
 
         print "Generating Test Case Management Reports"
 
+        cmd_prefix = os.environ.get('VECTORCAST_DIR') + os.sep
+
         # release locks and create all Test Case Management Report
-        callStr = "manage --project " + FullManageProjectName + " --force --release-locks"
+        callStr = cmd_prefix + "manage --project " + FullManageProjectName + " --force --release-locks"
         out_mgt = runManageWithWait(callStr)
 
         if level and envName:
-            callStr = "manage --project " + FullManageProjectName + " --level " + level + " --environment " + envName + " --clicast-args report custom management"
+            callStr = cmd_prefix + "manage --project " + FullManageProjectName + " --level " + level + " --environment " + envName + " --clicast-args report custom management"
         else:
-            callStr = "manage --project " + FullManageProjectName + " --clicast-args report custom management"
+            callStr = cmd_prefix + "manage --project " + FullManageProjectName + " --clicast-args report custom management"
         print callStr
 
         # capture the output of the manage call
@@ -456,9 +452,9 @@ def buildReports(FullManageProjectName = None, level = None, envName = None, gen
         if generate_individual_reports:
             print "Generating Execution Reports"
             if level and envName:
-                callStr = "manage --project " + FullManageProjectName + " --level " + level + " --environment " + envName + " --clicast-args report custom actual"
+                callStr = cmd_prefix + "manage --project " + FullManageProjectName + " --level " + level + " --environment " + envName + " --clicast-args report custom actual"
             else:
-                callStr = "manage --project " + FullManageProjectName + " --clicast-args report custom actual"
+                callStr = cmd_prefix + "manage --project " + FullManageProjectName + " --clicast-args report custom actual"
 
             print callStr
 

--- a/src/main/resources/scripts/managewait.py
+++ b/src/main/resources/scripts/managewait.py
@@ -38,7 +38,7 @@ class ManageWait():
         self.command_line = command_line
 
     def exec_manage(self, silent=False):
-        callStr = os.environ.get('VECTORCAST_DIR') + "manage " + self.command_line
+        callStr = os.environ.get('VECTORCAST_DIR') + os.sep + "manage " + self.command_line
         output = ''
         if self.verbose:
             output += "\nVerbose: %s" % callStr

--- a/src/main/resources/scripts/managewait.py
+++ b/src/main/resources/scripts/managewait.py
@@ -38,13 +38,7 @@ class ManageWait():
         self.command_line = command_line
 
     def exec_manage(self, silent=False):
-        # Versions of VectorCAST prior to 2019 relied on the environment variable VECTORCAST_DIR.
-        # We will use that variable as a fall back if the VectorCAST executables aren't on the system path.
-        exe_env = os.environ.copy()
-        if 'VECTORCAST_DIR' in os.environ:
-            exe_env['PATH'] = os.pathsep.join([os.environ.get('PATH', ''), exe_env['VECTORCAST_DIR']])
-
-        callStr = "manage " + self.command_line
+        callStr = os.environ.get('VECTORCAST_DIR') + "manage " + self.command_line
         output = ''
         if self.verbose:
             output += "\nVerbose: %s" % callStr
@@ -53,7 +47,7 @@ class ManageWait():
         loop_count = 0
         while 1:
             loop_count += 1
-            p = subprocess.Popen(callStr,stdout=subprocess.PIPE,stderr=subprocess.STDOUT, shell=True, env=exe_env)
+            p = subprocess.Popen(callStr,stdout=subprocess.PIPE,stderr=subprocess.STDOUT, shell=True)
             if not silent:
                 print("Manage started")
             license_outage = False


### PR DESCRIPTION
Currently this plugin is in limbo for support of vc2019sp2 for a customer not using VECTORCAST_DIR. The python scripts are set to handle this situation, but the Java changes (from 0.43) that enabled that feature got rolled back in commit e3739b2b794acb4c82831059ab6eceb886aad6f2. Due to that change a customer using vc2019sp2  without VECTORCAST_DIR set will have this plugin fail.

Eric's opinion is that since we have not formally told customers that they can run vc2019sp2+ without VECTORCAST_DIR set, we can assume these customers will all still have the environment variable set. Therefore rolling back all changes I made to the plugin is an option for now. Once customers are informed that they will not have to set VECTORCAST_DIR, then we will have to re-update this plugin, but we can cross that bridge when we get there.